### PR TITLE
(fix) small update

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -5,7 +5,7 @@ locals {
 resource "helm_release" "argocd" {
   name       = "argocd"
   repository = local.argocd_chart.repository
-  chart      = "argo-cd"
+  chart      = local.argocd_chart.name
   version    = local.argocd_chart.version
 
   namespace         = "argocd"

--- a/bootstrap/values.tf
+++ b/bootstrap/values.tf
@@ -1,7 +1,6 @@
 locals {
   helm_values = [{
     argo-cd = {
-      installCRDs = false
       configs = merge(length(var.repositories) > 0 ? {
         repositories = var.repositories
         } : null, {

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,6 @@ resource "argocd_application" "this" {
 
   cascade = false
 
-  wait = true
 
   spec {
     project = argocd_project.this.metadata.0.name


### PR DESCRIPTION
- remove wait = true in main.tf
This line seems to pose problems when we add configuration to Argo CD between the bootstrap and the “normal” module which causes Argo CD pods to restart (because the Argo CD provider seems to lose its port forward)
- remove obsolete value in value.tf
- get name from the chart in bootstrap/main.tf