### PR TITLE
feat: introduce a variable to set auto sync on the Argo CD application resource

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,11 +44,27 @@ The following input variables are optional (have default values):
 
 ==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
 
-Description: n/a
+Description: Automated sync options for the Argo CD Application resource.
 
-Type: `bool`
+Type:
+[source,hcl]
+----
+object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+----
 
-Default: `false`
+Default:
+[source,json]
+----
+{
+  "allow_empty": false,
+  "prune": true,
+  "self_heal": true
+}
+----
 
 ==== [[input_argocd]] <<input_argocd,argocd>>
 
@@ -208,9 +224,29 @@ Description: n/a
 |===
 |Name |Description |Type |Default |Required
 |[[input_app_autosync]] <<input_app_autosync,app_autosync>>
-|n/a
-|`bool`
-|`false`
+|Automated sync options for the Argo CD Application resource.
+|
+
+[source]
+----
+object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+----
+
+|
+
+[source]
+----
+{
+  "allow_empty": false,
+  "prune": true,
+  "self_heal": true
+}
+----
+
 |no
 
 |[[input_argocd]] <<input_argocd,argocd>>

--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,14 @@ No required inputs.
 
 The following input variables are optional (have default values):
 
+==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
+
+Description: n/a
+
+Type: `bool`
+
+Default: `false`
+
 ==== [[input_argocd]] <<input_argocd,argocd>>
 
 Description: ArgoCD settings
@@ -150,7 +158,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0"`
+Default: `"v1.0.0-alpha.1"`
 
 === Outputs
 
@@ -199,6 +207,12 @@ Description: n/a
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
+|[[input_app_autosync]] <<input_app_autosync,app_autosync>>
+|n/a
+|`bool`
+|`false`
+|no
+
 |[[input_argocd]] <<input_argocd,argocd>>
 |ArgoCD settings
 |`any`
@@ -282,7 +296,7 @@ Description: n/a
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0"`
+|`"v1.0.0-alpha.1"`
 |no
 
 |===

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,6 @@
+locals {
+  autosync = var.app_autosync ? { "allow_empty" = false, "prune" = true, "self_heal" = true } : {}
+}
 resource "null_resource" "dependencies" {
   triggers = var.dependency_ids
 }
@@ -62,11 +65,7 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = {
-        allow_empty = false
-        prune       = true
-        self_heal   = true
-      }
+      automated = local.autosync
 
       retry {
         backoff = {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,3 @@
-locals {
-  autosync = var.app_autosync ? { "allow_empty" = false, "prune" = true, "self_heal" = true } : {}
-}
 resource "null_resource" "dependencies" {
   triggers = var.dependency_ids
 }
@@ -65,7 +62,7 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = local.autosync
+      automated = var.app_autosync
 
       retry {
         backoff = {

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,15 @@ variable "target_revision" {
 }
 
 variable "app_autosync" {
-  type = bool
-  default = false
+  description = "Automated sync options for the Argo CD Application resource."
+  type = object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })  
+  default = { 
+    allow_empty = false
+    prune       = true
+    self_heal   = true
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,8 @@ variable "target_revision" {
   type        = string
   default     = "v1.0.0-alpha.1" # x-release-please-version
 }
+
+variable "app_autosync" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
autosync in argocd is set to false by default

This feature has been test on a scaleway instance