### PR TITLE
feat!: refact main argocd module

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,10 +43,49 @@ The following resources are used by this module:
 
 === Required Inputs
 
-No required inputs.
+The following input variables are required:
+
+==== [[input_accounts_pipeline_tokens]] <<input_accounts_pipeline_tokens,accounts_pipeline_tokens>>
+
+Description: API token for pipeline account.
+
+Type: `string`
+
+==== [[input_base_domain]] <<input_base_domain,base_domain>>
+
+Description: The base domain for building Ingress following DevOps Stack convention, e.g. argocd.apps.<cluster_name>.<base_domain>
+
+Type: `string`
+
+==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
+
+Description: Cluster Issuer
+
+Type: `string`
+
+==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
+
+Description: The name of the cluster to create.
+
+Type: `string`
+
+==== [[input_server_secretkey]] <<input_server_secretkey,server_secretkey>>
+
+Description: Signature key for session validation. Must reuse bootstrap secretkey.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
+
+==== [[input_admin_enabled]] <<input_admin_enabled,admin_enabled>>
+
+Description: Flag to indicate whether to enable admin user.
+
+Type: `bool`
+
+Default: `false`
 
 ==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
 
@@ -72,53 +111,13 @@ Default:
 }
 ----
 
-==== [[input_argocd]] <<input_argocd,argocd>>
-
-Description: ArgoCD settings
-
-Type: `any`
-
-Default: `{}`
-
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
-Description: n/a
+Description: Namespace for the resources AppProject and Application.
 
 Type: `string`
 
 Default: `"argocd"`
-
-==== [[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
-
-Description: ArgoCD Server Secert Key to avoid regenerate token on redeploy.
-
-Type: `string`
-
-Default: `null`
-
-==== [[input_base_domain]] <<input_base_domain,base_domain>>
-
-Description: The base domain used for Ingresses.
-
-Type: `string`
-
-Default: `""`
-
-==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
-
-Description: Cluster Issuer
-
-Type: `string`
-
-Default: `""`
-
-==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
-
-Description: The name of the cluster to create.
-
-Type: `string`
-
-Default: `""`
 
 ==== [[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 
@@ -146,7 +145,7 @@ Default:
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
-Description: n/a
+Description: Destination Namespace for Application child resources.
 
 Type: `string`
 
@@ -226,6 +225,18 @@ Description: n/a
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
+|[[input_accounts_pipeline_tokens]] <<input_accounts_pipeline_tokens,accounts_pipeline_tokens>>
+|API token for pipeline account.
+|`string`
+|n/a
+|yes
+
+|[[input_admin_enabled]] <<input_admin_enabled,admin_enabled>>
+|Flag to indicate whether to enable admin user.
+|`bool`
+|`false`
+|no
+
 |[[input_app_autosync]] <<input_app_autosync,app_autosync>>
 |Automated sync options for the Argo CD Application resource.
 |
@@ -252,41 +263,29 @@ object({
 
 |no
 
-|[[input_argocd]] <<input_argocd,argocd>>
-|ArgoCD settings
-|`any`
-|`{}`
-|no
-
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|n/a
+|Namespace for the resources AppProject and Application.
 |`string`
 |`"argocd"`
 |no
 
-|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
-|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
-|`string`
-|`null`
-|no
-
 |[[input_base_domain]] <<input_base_domain,base_domain>>
-|The base domain used for Ingresses.
+|The base domain for building Ingress following DevOps Stack convention, e.g. argocd.apps.<cluster_name>.<base_domain>
 |`string`
-|`""`
-|no
+|n/a
+|yes
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |Cluster Issuer
 |`string`
-|`""`
-|no
+|n/a
+|yes
 
 |[[input_cluster_name]] <<input_cluster_name,cluster_name>>
 |The name of the cluster to create.
 |`string`
-|`""`
-|no
+|n/a
+|yes
 
 |[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 |n/a
@@ -311,7 +310,7 @@ object({
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
-|n/a
+|Destination Namespace for Application child resources.
 |`string`
 |`"argocd"`
 |no
@@ -327,6 +326,12 @@ object({
 |`map(map(string))`
 |`{}`
 |no
+
+|[[input_server_secretkey]] <<input_server_secretkey,server_secretkey>>
+|Signature key for session validation. Must reuse bootstrap secretkey.
+|`string`
+|n/a
+|yes
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.

--- a/README.md
+++ b/README.md
@@ -4,27 +4,26 @@ A [DevOps Stack](https://devops-stack.io) module to finalize [ArgoCD](https://ar
 
 While the `argocd-helm` module deploys a bootstrap ArgoCD, this module allows to finalize its installation and should be called at the end of all DevOps Stack modules.
 
-
 ## Usage
 
 ```hcl
 module "argocd" {
   source = "git::https://github.com/camptocamp/devops-stack-module-argocd.git/"
 
-  cluster_name   = var.cluster_name
-  oidc           = module.oidc.oidc
-  argocd         = {
-    namespace = module.cluster.argocd_namespace
-    server_secretkey = module.cluster.argocd_server_secretkey
-    accounts_pipeline_tokens = module.cluster.argocd_accounts_pipeline_tokens
-    server_admin_password = module.cluster.argocd_server_admin_password
-    domain = module.cluster.argocd_domain
-    admin_enabled = true
-  }
-  base_domain    = module.cluster.base_domain
-  cluster_issuer = "letsencrypt-prod"
+  base_domain              = "example.com"
+  cluster_name             = "my-cluster"
+  cluster_issuer           = "letsencrypt-prod"
+  admin_enabled            = "true"
+  namespace                = local.argocd_namespace
+  accounts_pipeline_tokens = module.argocd_bootstrap[0].argocd_accounts_pipeline_tokens
+  server_secretkey         = module.argocd_bootstrap[0].argocd_server_secretkey
 
-  depends_on = [ module.cert-manager, module.monitoring ]
+
+dependency_ids = {
+    prometheus   = module.prometheus-stack[0].id
+    cert-manager = module.cert-manager[0].id
+  }
 }
 ```
 
+Once module is applied and argocd Application synched, service becomes available at `argocd.apps.my-cluster.example.com`

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,11 @@
 variable "cluster_name" {
   description = "The name of the cluster to create."
   type        = string
-  default     = ""
-}
-
-variable "base_domain" {
-  description = "The base domain used for Ingresses."
-  type        = string
-  default     = ""
 }
 
 variable "cluster_issuer" {
   description = "Cluster Issuer"
   type        = string
-  default     = ""
 }
 
 variable "oidc" {
@@ -22,10 +14,9 @@ variable "oidc" {
   default     = null
 }
 
-variable "argocd" {
-  description = "ArgoCD settings"
-  type        = any
-  default     = {}
+variable "base_domain" {
+  description = "The base domain for building Ingress following DevOps Stack convention, e.g. argocd.apps.<cluster_name>.<base_domain>"
+  type        = string
 }
 
 variable "repositories" {
@@ -42,20 +33,16 @@ variable "helm_values" {
   }]
 }
 
-variable "argocd_server_secretkey" {
-  description = "ArgoCD Server Secert Key to avoid regenerate token on redeploy."
-  type        = string
-  default     = null
-}
-
 variable "namespace" {
-  type    = string
-  default = "argocd"
+  description = "Destination Namespace for Application child resources."
+  type        = string
+  default     = "argocd"
 }
 
 variable "argocd_namespace" {
-  type    = string
-  default = "argocd"
+  description = "Namespace for the resources AppProject and Application."
+  type        = string
+  default     = "argocd"
 }
 
 variable "dependency_ids" {
@@ -81,4 +68,22 @@ variable "app_autosync" {
     prune       = true
     self_heal   = true
   }
+}
+
+variable "admin_enabled" {
+  description = "Flag to indicate whether to enable admin user."
+  type        = bool
+  default     = false
+}
+
+variable "accounts_pipeline_tokens" {
+  description = "API token for pipeline account."
+  type        = string
+  sensitive   = true
+}
+
+variable "server_secretkey" {
+  description = "Signature key for session validation. Must reuse bootstrap secretkey."
+  type        = string
+  sensitive   = false
 }


### PR DESCRIPTION
* feat!: flatten user interface by dropping usage of `var.argocd` and using standard vars instead
* feat!: drop `domain` var, build this based on devops stack ingress conventions and cluster name
* feat: document variable usage
* feat!: make some new variables now mandatory

see README.md for example