### PR TITLE
fix(bootstrap): get chart version from Chart.lock

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,5 +1,5 @@
 locals {
-  argocd_chart = yamldecode(file("${path.module}/../charts/argocd/Chart.yaml")).dependencies.0
+  argocd_chart = yamldecode(file("${path.module}/../charts/argocd/Chart.lock")).dependencies.0
 }
 
 # argocd secret key for token generation, it should be passed to next argocd generation


### PR DESCRIPTION
Chart.yaml currently has a fuzzy dependency version, which means that the bootstrap module would not install the exact same version as the main argocd module. Thi would leading to a downgrade when the main module creates the argocd app to manage itself.