### PR TITLE
feat: add new default administrator group

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,10 +27,6 @@ The following providers are used by this module:
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
-=== Modules
-
-No modules.
-
 === Resources
 
 The following resources are used by this module:

--- a/README.adoc
+++ b/README.adoc
@@ -173,7 +173,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.6"`
+Default: `"v1.0.0-alpha.7"`
 
 === Outputs
 
@@ -336,7 +336,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.6"`
+|`"v1.0.0-alpha.7"`
 |no
 
 |===

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -29,10 +29,6 @@ The following providers are used by this module:
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
-=== Modules
-
-No modules.
-
 === Resources
 
 The following resources are used by this module:
@@ -45,9 +41,6 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static[time_static.iat] (resource)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
-=== Required Inputs
-
-No required inputs.
 === Optional Inputs
 
 The following input variables are optional (have default values):

--- a/bootstrap/locals.tf
+++ b/bootstrap/locals.tf
@@ -66,7 +66,7 @@ locals {
           "policy.default" = ""
           "policy.csv"     = <<-EOT
                               g, pipeline, role:admin
-                              g, argocd-admin, role:admin
+                              g, devops-stack-admins, role:admin
                               EOT
         }
         secret = {

--- a/bootstrap/locals.tf
+++ b/bootstrap/locals.tf
@@ -66,6 +66,7 @@ locals {
           "policy.default" = ""
           "policy.csv"     = <<-EOT
                               g, pipeline, role:admin
+                              g, argocd-admin, role:admin
                               g, devops-stack-admins, role:admin
                               EOT
         }

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,7 @@ locals {
           "policy.default" = ""
           "policy.csv"     = <<-EOT
                               g, pipeline, role:admin
+                              g, argocd-admin, role:admin
                               g, devops-stack-admins, role:admin
                             EOT
         }

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
           "policy.default" = ""
           "policy.csv"     = <<-EOT
                               g, pipeline, role:admin
-                              g, argocd-admin, role:admin
+                              g, devops-stack-admins, role:admin
                             EOT
         }
         secret = {


### PR DESCRIPTION
This is just a proposition and has not been tested, although it is such a small change that in theory it should work :wink:

I'll explain my reasoning behind this. While refactoring the Keycloak and AWS OIDC modules, I added the option to let the modules themselves create an administrator group in their user pools. I named said group `devops-stack-admins` a I said to myself that these users would have administrative access to more than Argo CD, so it seemed to me that the `argocd-admin` name was not clear enough. With this change, any cluster deployed with the users and groups from those modules would have access to Argo CD without needing to add a policy CSV on the root code, which would facilitate tests and the deployment of ephemeral clusters, I think.

An alternative to replacing `argocd-admin` by `devops-stack-admin` would be keeping both groups, I'll leave that to discuss amongst ourselves.