### PR TITLE
feat: support extra accounts token generation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,13 @@ The following providers are used by this module:
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4.2)
 
+- [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
+
 - [[provider_null]] <<provider_null,null>>
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_time]] <<provider_time,time>> (>= 0.9)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
@@ -33,8 +39,11 @@ The following resources are used by this module:
 
 - https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] (resource)
 - https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] (resource)
+- https://registry.terraform.io/providers/camptocamp/jwt/latest/docs/resources/hashed_token[jwt_hashed_token.tokens] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
+- https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid[random_uuid.jti] (resource)
+- https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static[time_static.iat] (resource)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
 === Required Inputs
@@ -123,6 +132,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_extra_accounts]] <<input_extra_accounts,extra_accounts>>
+
+Description: List of accounts for which tokens will be generated.
+
+Type: `list(string)`
+
+Default: `[]`
+
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
 Description: Helm values, passed as a list of HCL structures.
@@ -175,6 +192,10 @@ Default: `"v1.0.0"`
 
 The following outputs are exported:
 
+==== [[output_extra_tokens]] <<output_extra_tokens,extra_tokens>>
+
+Description: Map of extra accounts and their tokens.
+
 ==== [[output_id]] <<output_id,id>>
 
 Description: n/a
@@ -200,7 +221,10 @@ Description: n/a
 |===
 |Name |Version
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4.2
+|[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |===
 
@@ -211,8 +235,11 @@ Description: n/a
 |Name |Type
 |https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] |resource
 |https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] |resource
+|https://registry.terraform.io/providers/camptocamp/jwt/latest/docs/resources/hashed_token[jwt_hashed_token.tokens] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
+|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid[random_uuid.jti] |resource
+|https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static[time_static.iat] |resource
 |https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] |data source
 |===
 
@@ -289,6 +316,12 @@ object({
 |`{}`
 |no
 
+|[[input_extra_accounts]] <<input_extra_accounts,extra_accounts>>
+|List of accounts for which tokens will be generated.
+|`list(string)`
+|`[]`
+|no
+
 |[[input_helm_values]] <<input_helm_values,helm_values>>
 |Helm values, passed as a list of HCL structures.
 |`any`
@@ -342,6 +375,7 @@ object({
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Description
+|[[output_extra_tokens]] <<output_extra_tokens,extra_tokens>> |Map of extra accounts and their tokens.
 |[[output_id]] <<output_id,id>> |n/a
 |===
 // END_TF_TABLES

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,22 @@ resource "null_resource" "dependencies" {
   triggers = var.dependency_ids
 }
 
+resource "jwt_hashed_token" "tokens" {
+  for_each = toset(var.extra_accounts)
+
+  algorithm   = "HS256"
+  secret      = var.server_secretkey
+  claims_json = jsonencode(local.jwt_tokens[each.value])
+}
+
+resource "time_static" "iat" {
+  for_each = toset(var.extra_accounts)
+}
+
+resource "random_uuid" "jti" {
+  for_each = toset(var.extra_accounts)
+}
+
 resource "argocd_project" "this" {
   metadata {
     name      = "argocd"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,9 @@
 output "id" {
   value = resource.null_resource.this.id
 }
+
+output "extra_tokens" {
+  description = "Map of extra accounts and their tokens."
+  value       = {for account in var.extra_accounts : account => jwt_hashed_token.tokens[account].token}
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,9 @@ variable "server_secretkey" {
   type        = string
   sensitive   = false
 }
+
+variable "extra_accounts" {
+  description = "List of accounts for which tokens will be generated."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Description of the changes

Currently, a single account `pipeline` is created and given admin role and a token for API access. This PR allows passing a list of account names to the optional `extra_accounts` variable. Tokens are generated for these accounts for API access and returned using `extra_tokens` output.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s))
- [ ] Yes (in the module itself)

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)