### PR TITLE
feat!: add helmfile-sops custom plugin installation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,6 +114,15 @@ module "argocd" {
 
 NOTE: By default, this module has a `policy.csv` that is configured to give administrator access to any user belonging to the groups `argocd-admin` or `devops-stack-admins`.
 
+== Custom Plugins
+
+This module installs two custom plugins:
+
+1. "kustomized-helm" is just a combination of Kustomize and Helm that allows using Helm charts and then applying Kustomize overrides to the result.
+2. "helmfile-sops" adds support for Helmfile managed applications, and integrates the support for SOPS. This is a custom plugin developped by Camptocamp: https://github.com/camptocamp/docker-argocd-cmp-helmfile
+
+NOTE: When using SOPS, you will want to give it access to an external secrets management or encryption service. For this, you an attach an AWS IAM role to the argocd-repo-server ServiceAccount or an Azzre AAD Pod Identity using the variables `repo_server_iam_role_arn` or `repo_server_aadpodidbinding`.
+
 == Troubleshooting
 
 When deploying this module of Argo CD you may experience connection errors (which is normal given that argocd-server pod could have been redeployed).

--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,7 @@ NOTE: By default, this module has a `policy.csv` that is configured to give admi
 This module installs two custom plugins:
 
 1. "kustomized-helm" is just a combination of Kustomize and Helm that allows using Helm charts and then applying Kustomize overrides to the result.
-2. "helmfile-sops" adds support for Helmfile managed applications, and integrates the support for SOPS. This is a custom plugin developped by Camptocamp: https://github.com/camptocamp/docker-argocd-cmp-helmfile
+2. "helmfile-sops" adds support for Helmfile managed applications, and integrates the support for https://github.com/mozilla/sops[SOPS]. This is a custom plugin developed by Camptocamp (source code available https://github.com/camptocamp/docker-argocd-cmp-helmfile[here]).
 
 NOTE: When using SOPS, you will want to give it access to an external secrets management or encryption service. For this, you will want to pass an AWS IAM role, and Azure Workload Identity Client-ID, or an Azure AAD Pod Identity using the variables `repo_server_iam_role_arn`, repo_server_azure_workload_identity_clientid`, or `repo_server_aadpodidbinding`.
 

--- a/README.adoc
+++ b/README.adoc
@@ -391,6 +391,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_repo_server_azure_workload_identity_clientid]] <<input_repo_server_azure_workload_identity_clientid,repo_server_azure_workload_identity_clientid>>
+
+Description: Azure AD Workload Identity Client-ID to associate with argocd-repo-server. This role can be used to give SOPS access to a Key Vault.
+
+Type: `string`
+
+Default: `null`
+
 ==== [[input_repo_server_aadpodidbinding]] <<input_repo_server_aadpodidbinding,repo_server_aadpodidbinding>>
 
 Description: Azure AAD Pod Identity to associate with the argocd-repo-server Pod. This role can be used to give SOPS access to a Key Vault.
@@ -588,6 +596,12 @@ object({
 
 |[[input_repo_server_iam_role_arn]] <<input_repo_server_iam_role_arn,repo_server_iam_role_arn>>
 |IAM role ARN to associate with the argocd-repo-server ServiceAccount. This role can be used to give SOPS access to AWS KMS.
+|`string`
+|`null`
+|no
+
+|[[input_repo_server_azure_workload_identity_clientid]] <<input_repo_server_azure_workload_identity_clientid,repo_server_azure_workload_identity_clientid>>
+|Azure AD Workload Identity Client-ID to associate with argocd-repo-server. This role can be used to give SOPS access to a Key Vault.
 |`string`
 |`null`
 |no

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,7 @@ This module installs two custom plugins:
 1. "kustomized-helm" is just a combination of Kustomize and Helm that allows using Helm charts and then applying Kustomize overrides to the result.
 2. "helmfile-sops" adds support for Helmfile managed applications, and integrates the support for SOPS. This is a custom plugin developped by Camptocamp: https://github.com/camptocamp/docker-argocd-cmp-helmfile
 
-NOTE: When using SOPS, you will want to give it access to an external secrets management or encryption service. For this, you an attach an AWS IAM role to the argocd-repo-server ServiceAccount or an Azzre AAD Pod Identity using the variables `repo_server_iam_role_arn` or `repo_server_aadpodidbinding`.
+NOTE: When using SOPS, you will want to give it access to an external secrets management or encryption service. For this, you will want to pass an AWS IAM role, and Azure Workload Identity Client-ID, or an Azure AAD Pod Identity using the variables `repo_server_iam_role_arn`, repo_server_azure_workload_identity_clientid`, or `repo_server_aadpodidbinding`.
 
 == Troubleshooting
 

--- a/README.adoc
+++ b/README.adoc
@@ -214,6 +214,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -223,8 +225,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4.2)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -214,8 +214,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -225,6 +223,8 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4.2)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -285,7 +285,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.1"`
+Default: `"v1.1.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -383,6 +383,22 @@ Type: `list(string)`
 
 Default: `[]`
 
+==== [[input_repo_server_iam_role_arn]] <<input_repo_server_iam_role_arn,repo_server_iam_role_arn>>
+
+Description: IAM role ARN to associate with the argocd-repo-server ServiceAccount. This role can be used to give SOPS access to AWS KMS.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_repo_server_aadpodidbinding]] <<input_repo_server_aadpodidbinding,repo_server_aadpodidbinding>>
+
+Description: Azure AAD Pod Identity to associate with the argocd-repo-server Pod. This role can be used to give SOPS access to a Key Vault.
+
+Type: `string`
+
+Default: `null`
+
 === Outputs
 
 The following outputs are exported:
@@ -471,7 +487,7 @@ Description: Map of extra accounts and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.1"`
+|`"v1.1.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -568,6 +584,18 @@ object({
 |List of accounts for which tokens will be generated.
 |`list(string)`
 |`[]`
+|no
+
+|[[input_repo_server_iam_role_arn]] <<input_repo_server_iam_role_arn,repo_server_iam_role_arn>>
+|IAM role ARN to associate with the argocd-repo-server ServiceAccount. This role can be used to give SOPS access to AWS KMS.
+|`string`
+|`null`
+|no
+
+|[[input_repo_server_aadpodidbinding]] <<input_repo_server_aadpodidbinding,repo_server_aadpodidbinding>>
+|Azure AAD Pod Identity to associate with the argocd-repo-server Pod. This role can be used to give SOPS access to a Key Vault.
+|`string`
+|`null`
 |no
 
 |===

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -61,11 +61,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
 

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -163,9 +163,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_null]] <<provider_null,null>> |n/a

--- a/locals.tf
+++ b/locals.tf
@@ -21,6 +21,113 @@ locals {
     }
   ]), "\\\"", "\"") }
 
+  extra_objects = [
+    {
+      apiVersion = "v1"
+      kind       = "ConfigMap"
+      metadata = {
+        name = "kustomized-helm-cm"
+      }
+      data = {
+        "plugin.yaml" = <<-EOT
+          apiVersion: argoproj.io/v1alpha1
+          kind: ConfigManagementPlugin
+          metadata:
+            name: kustomized-helm
+          spec:
+            init:
+              command: ["/bin/sh", "-c"]
+              args: ["helm dependency build || true"]
+            generate:
+              command: ["/bin/sh", "-c"]
+              args: ["echo \"$ARGOCD_ENV_HELM_VALUES\" | helm template . --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE $ARGOCD_ENV_HELM_ARGS -f - --include-crds > all.yaml && kustomize build"]
+        EOT
+      }
+    }
+  ]
+
+  repo_server_extra_containers = [
+    {
+      name    = "kustomized-helm-cmp"
+      command = ["/var/run/argocd/argocd-cmp-server"]
+      # Note: Argo CD official image ships Helm and Kustomize. No need to build a custom image to use "kustomized-helm" plugin.
+      image = "quay.io/argoproj/argocd:${local.argocd_version}"
+      securityContext = {
+        runAsNonRoot = true
+        runAsUser    = 999
+      }
+      volumeMounts = [
+        {
+          mountPath = "/var/run/argocd"
+          name      = "var-files"
+        },
+        {
+          mountPath = "/home/argocd/cmp-server/plugins"
+          name      = "plugins"
+        },
+        {
+          mountPath = "/home/argocd/cmp-server/config/plugin.yaml"
+          subPath   = "plugin.yaml"
+          name      = "kustomized-helm-cm"
+        },
+        {
+          mountPath = "/tmp"
+          name      = "kustomized-helm-cmp-tmp"
+        }
+      ]
+    },
+    {
+      name    = "helmfile-cmp"
+      command = ["/var/run/argocd/argocd-cmp-server"]
+      image   = "ghcr.io/camptocamp/docker-argocd-cmp-helmfile:0.0.12"
+      securityContext = {
+        runAsNonRoot = true
+        runAsUser    = 999
+      }
+      terminationMessagePath   = "/dev/termination-log"
+      terminationMessagePolicy = "File"
+      volumeMounts = [
+        {
+          mountPath = "/var/run/argocd"
+          name      = "var-files"
+        },
+        {
+          mountPath = "/home/argocd/cmp-server/plugins"
+          name      = "plugins"
+        },
+        {
+          mountPath = "/tmp"
+          name      = "helmfile-cmp-tmp"
+        }
+      ]
+    }
+  ]
+
+  repo_server_volumes = [
+    {
+      configMap = {
+        name = "kustomized-helm-cm"
+      }
+      name = "kustomized-helm-cm"
+    },
+    {
+      name     = "helmfile-cmp-tmp"
+      emptyDir = {}
+    },
+    {
+      name     = "kustomized-helm-cmp-tmp"
+      emptyDir = {}
+    }
+  ]
+
+  repo_server_service_account_annotations = merge(
+    var.repo_server_iam_role_arn != null ? { "eks.amazonaws.com/role-arn" = var.repo_server_iam_role_arn } : {}
+  )
+
+  repo_server_pod_labels = merge(
+    var.repo_server_aadpodidbinding != null ? { "aadpodidbinding" : var.repo_server_aadpodidbinding } : {}
+  )
+
   helm_values = [{
     argo-cd = {
       configs = merge(length(var.repositories) > 0 ? {
@@ -55,66 +162,14 @@ locals {
         metrics = {
           enabled = true
         }
-        volumes = [
-          {
-            configMap = {
-              name = "kustomized-helm-cm"
-            }
-            name = "kustomized-helm-volume"
-          }
-        ]
-        extraContainers = [
-          {
-            name    = "kustomized-helm-cmp"
-            command = ["/var/run/argocd/argocd-cmp-server"]
-            # Note: Argo CD official image ships Helm and Kustomize. No need to build a custom image to use "kustomized-helm" plugin.
-            image = "quay.io/argoproj/argocd:${local.argocd_version}"
-            securityContext = {
-              runAsNonRoot = true
-              runAsUser    = 999
-            }
-            volumeMounts = [
-              {
-                mountPath = "/var/run/argocd"
-                name      = "var-files"
-              },
-              {
-                mountPath = "/home/argocd/cmp-server/plugins"
-                name      = "plugins"
-              },
-              {
-                mountPath = "/home/argocd/cmp-server/config/plugin.yaml"
-                subPath   = "plugin.yaml"
-                name      = "kustomized-helm-volume"
-              }
-            ]
-          }
-        ]
-      }
-      extraObjects = [
-        {
-          apiVersion = "v1"
-          kind       = "ConfigMap"
-          metadata = {
-            name = "kustomized-helm-cm"
-          }
-          data = {
-            "plugin.yaml" = <<-EOT
-              apiVersion: argoproj.io/v1alpha1
-              kind: ConfigManagementPlugin
-              metadata:
-                name: kustomized-helm
-              spec:
-                init:
-                  command: ["/bin/sh", "-c"]
-                  args: ["helm dependency build || true"]
-                generate:
-                  command: ["/bin/sh", "-c"]
-                  args: ["echo \"$ARGOCD_ENV_HELM_VALUES\" | helm template . --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE $ARGOCD_ENV_HELM_ARGS -f - --include-crds > all.yaml && kustomize build"]
-            EOT
-          }
+        volumes         = local.repo_server_volumes
+        extraContainers = local.repo_server_extra_containers
+        podLabels       = local.repo_server_pod_labels
+        serviceAccount = {
+          annotations = local.repo_server_service_account_annotations
         }
-      ]
+      }
+      extraObjects = local.extra_objects
       server = merge(
         {
           extraArgs = [

--- a/locals.tf
+++ b/locals.tf
@@ -121,10 +121,14 @@ locals {
   ]
 
   repo_server_service_account_annotations = merge(
-    var.repo_server_iam_role_arn != null ? { "eks.amazonaws.com/role-arn" = var.repo_server_iam_role_arn } : {}
+    var.repo_server_iam_role_arn != null ? { "eks.amazonaws.com/role-arn" = var.repo_server_iam_role_arn } : {},
+    var.repo_server_azure_workload_identity_clientid != null ? { "azure.workload.identity/client-id" = var.repo_server_azure_workload_identity_clientid } : {}
   )
 
+  repo_server_service_account_labels = var.repo_server_azure_workload_identity_clientid != null ? { "azure.workload.identity/use" : "true" } : {}
+
   repo_server_pod_labels = merge(
+    var.repo_server_azure_workload_identity_clientid != null ? { "azure.workload.identity/use" : "true" } : {},
     var.repo_server_aadpodidbinding != null ? { "aadpodidbinding" : var.repo_server_aadpodidbinding } : {}
   )
 
@@ -167,6 +171,7 @@ locals {
         podLabels       = local.repo_server_pod_labels
         serviceAccount = {
           annotations = local.repo_server_service_account_annotations
+          labels      = local.repo_server_service_account_labels
         }
       }
       extraObjects = local.extra_objects

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "repo_server_iam_role_arn" {
   default     = null
 }
 
+variable "repo_server_azure_workload_identity_clientid" {
+  description = "Azure AD Workload Identity Client-ID to associate with argocd-repo-server. This role can be used to give SOPS access to a Key Vault."
+  type        = string
+  default     = null
+}
+
 variable "repo_server_aadpodidbinding" {
   description = "Azure AAD Pod Identity to associate with the argocd-repo-server Pod. This role can be used to give SOPS access to a Key Vault."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,15 @@ variable "extra_accounts" {
   type        = list(string)
   default     = []
 }
+
+variable "repo_server_iam_role_arn" {
+  description = "IAM role ARN to associate with the argocd-repo-server ServiceAccount. This role can be used to give SOPS access to AWS KMS."
+  type        = string
+  default     = null
+}
+
+variable "repo_server_aadpodidbinding" {
+  description = "Azure AAD Pod Identity to associate with the argocd-repo-server Pod. This role can be used to give SOPS access to a Key Vault."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description of the changes

Install the camptocamp helmfile plugin that integrates support for SOPS. This replaces the manual addition to helm_values that we're already using in multiple deployments. If the plugin in unused, the overhead should be negligible.

This is an 

## Breaking change

No when not using helmfile, the addition of the helmfile plugin has no influence on existing argocd installations as long as no `helmfile.yaml` files are present in appplications.

YES when already using the helmfile via helm_values, the custom configuration should be removed from the call to this module to avoid duplication, and the IAM role or AAD pod identity should be passed to the module.

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [x] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)