### PR TITLE
fix: add default value to the rbac variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -255,25 +255,6 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
-==== [[input_rbac]] <<input_rbac,rbac>>
-
-Description: RBAC settings for the Argo CD users.
-
-Type:
-[source,hcl]
-----
-object({
-    scopes         = optional(string, "[groups, cognito:groups, roles]")
-    policy_default = optional(string, "")
-    policy_csv = optional(string, <<-EOT
-                                    g, pipeline, role:admin
-                                    g, argocd-admin, role:admin
-                                    g, devops-stack-admins, role:admin
-                                  EOT
-    )
-  })
-----
-
 ==== [[input_accounts_pipeline_tokens]] <<input_accounts_pipeline_tokens,accounts_pipeline_tokens>>
 
 Description: API token for pipeline account.
@@ -304,7 +285,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -328,15 +309,7 @@ Description: Helm chart value overrides. They should be passed as a list of HCL 
 
 Type: `any`
 
-Default:
-[source,json]
-----
-[
-  {
-    "argo-cd": {}
-  }
-]
-----
+Default: `[]`
 
 ==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
 
@@ -377,6 +350,27 @@ Description: OIDC settings for the log in to the Argo CD web interface.
 Type: `any`
 
 Default: `null`
+
+==== [[input_rbac]] <<input_rbac,rbac>>
+
+Description: RBAC settings for the Argo CD users.
+
+Type:
+[source,hcl]
+----
+object({
+    scopes         = optional(string, "[groups, cognito:groups, roles]")
+    policy_default = optional(string, "")
+    policy_csv = optional(string, <<-EOT
+                                    g, pipeline, role:admin
+                                    g, argocd-admin, role:admin
+                                    g, devops-stack-admins, role:admin
+                                  EOT
+    )
+  })
+----
+
+Default: `{}`
 
 ==== [[input_repositories]] <<input_repositories,repositories>>
 
@@ -510,12 +504,12 @@ Description: Map of extra accounts that were created and their tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -559,7 +553,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -577,17 +571,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_helm_values]] <<input_helm_values,helm_values>>
 |Helm chart value overrides. They should be passed as a list of HCL structures.
 |`any`
-|
-
-[source]
-----
-[
-  {
-    "argo-cd": {}
-  }
-]
-----
-
+|`[]`
 |no
 
 |[[input_app_autosync]] <<input_app_autosync,app_autosync>>
@@ -646,8 +630,8 @@ object({
   })
 ----
 
-|n/a
-|yes
+|`{}`
+|no
 
 |[[input_repositories]] <<input_repositories,repositories>>
 |List of repositories to add to Argo CD.

--- a/variables.tf
+++ b/variables.tf
@@ -39,9 +39,7 @@ variable "namespace" {
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any
-  default = [{
-    argo-cd = {}
-  }]
+  default     = []
 }
 
 variable "app_autosync" {
@@ -85,6 +83,7 @@ variable "rbac" {
                                   EOT
     )
   })
+  default = {}
 }
 
 variable "repositories" {


### PR DESCRIPTION
## Description of the changes

[On my last PR](https://github.com/camptocamp/devops-stack-module-argocd/pull/56), when I added the `rbac` variable, I did no include a default value because I thought it would not be needed since we had a optionals on the variable structure. On a few tests later, I noticed that was not the case, so I this PR fixes that.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)
- [x] SKS (Exoscale)