### PR TITLE
fix: change default to null to not remove the default known_hosts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -285,7 +285,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.1.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -382,11 +382,11 @@ Default: `{}`
 
 ==== [[input_ssh_known_hosts]] <<input_ssh_known_hosts,ssh_known_hosts>>
 
-Description: List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value.
+Description: List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value. **If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here.**
 
 Type: `string`
 
-Default: `""`
+Default: `null`
 
 ==== [[input_exec_enabled]] <<input_exec_enabled,exec_enabled>>
 
@@ -553,7 +553,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.1.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -640,9 +640,9 @@ object({
 |no
 
 |[[input_ssh_known_hosts]] <<input_ssh_known_hosts,ssh_known_hosts>>
-|List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value.
+|List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value. **If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here.**
 |`string`
-|`""`
+|`null`
 |no
 
 |[[input_exec_enabled]] <<input_exec_enabled,exec_enabled>>

--- a/variables.tf
+++ b/variables.tf
@@ -93,9 +93,9 @@ variable "repositories" {
 }
 
 variable "ssh_known_hosts" {
-  description = "List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value."
+  description = "List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value. **If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here.**"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "exec_enabled" {


### PR DESCRIPTION
## Description of the changes

When I added the variable `ssh_known_hosts`, I set the default as an empty string. This had the effect of removing all the default known hosts on the chart of Argo CD. Setting this value to `null` allows the default hosts to be deployed.

Still, if this variable is set, only the hosts that are passed will be set and you will need to add the hosts you need from the default values manually. I consider this a desirable effect, since it gives the user the chance to lock out its Argo CD and to only deploy the known hosts it wants, similarly to what the chart provides.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)