### PR TITLE
fix: fix the activation of the web-terminal on Argo CD

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -231,9 +231,9 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
 === Resources
 
@@ -294,7 +294,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.3.0"`
+Default: `"v3.4.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -562,7 +562,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.3.0"`
+|`"v3.4.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -61,11 +61,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
-
-- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
 
@@ -163,9 +163,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_null]] <<provider_null,null>> |n/a

--- a/locals.tf
+++ b/locals.tf
@@ -141,10 +141,6 @@ locals {
         ssh = {
           knownHosts = var.ssh_known_hosts
         }
-        cm = {
-          "admin.enabled" = var.admin_enabled
-          "exec.enabled"  = var.exec_enabled
-        }
         rbac = {
           scopes           = var.rbac.scopes
           "policy.default" = var.rbac.policy_default
@@ -185,6 +181,8 @@ locals {
         ]
         config = merge({ for account in var.extra_accounts : format("accounts.%s", account) => "apiKey" }, {
           "url"                           = "https://${local.argocd_hostname_withclustername}"
+          "admin.enabled"                 = tostring(var.admin_enabled)
+          "exec.enabled"                  = tostring(var.exec_enabled)
           "accounts.pipeline"             = "apiKey"
           "oidc.config"                   = <<-EOT
             ${yamlencode(merge(var.oidc, { clientSecret = "$oidc.default.clientSecret" }))}


### PR DESCRIPTION
## Description of the changes

Using the `cm` value to enable the web-terminal does not work because we also set the `server.config` value. The problem with this, is that [this condition](https://github.com/argoproj/argo-helm/blob/4afebb25f60aeeadb7c4365ab2fc1824185d0aa8/charts/argo-cd/templates/argocd-server/clusterrole.yaml#L31) would not work because of the `coalesce()` and the `ClusterRole` was created without the required permissions.

Because of this, I put the `exec.enabled` and the `admin.enabled` inside the `server.config` value. 

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] SKS (Exoscale)