### PR TITLE
feat: add way to create and use unified AppProject, add labels and add support for HA mode

### DIFF
--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -1,4 +1,4 @@
-= Argo CD Bootstrap module
+= Argo CD Bootstrap Module
 
 This module is used to bootstrap the Argo CD that will deploy the rest of the DevOps Stack modules on a first deployment of a cluster.
 
@@ -11,7 +11,7 @@ To do that, on your Terraform configuration you can declare the module as such:
 [source,terraform]
 ----
 module "argocd_bootstrap" {
-  source = "git::https://github.com/camptocamp/devops-stack-module-argocd.git//bootstrap?ref=v1.1.0"
+  source = "git::https://github.com/camptocamp/devops-stack-module-argocd.git//bootstrap?ref=<RELEASE>"
 
   # Note here that you should mark the module as depending on the module that deployed the cluster
   depends_on = [module.eks]
@@ -35,6 +35,24 @@ provider "argocd" {
   }
 }
 ----
+
+=== Unified AppProject
+
+By default, all the modules of the DevOps Stack create their own AppProject to deploy the Argo CD Application deployed by the module. *Since the version 3.5.0* of this module, the bootstrap module now supports creating AppProjects for a given map of projects passed in the variable `argocd_projects`. The DevOps Stack modules then can be configured to use this unified AppProject instead of creating on for each application.
+
+TIP: By default, the AppProjects created by this module do not contain restrictions for the destination namespace or source repositories, but you can change that behavior by configuring the `allowed_source_repos` and `allowed_namespaces` values on the `argocd_projects` map.
+
+==== Migrating from split AppProjects to a unified AppProject
+
+This process requires a few manual steps, because Terraform will try to delete the old AppProjects before referencing the Applications to the new AppProject. To accomplish this, do the following:
+
+1. Create the new AppProject with the `argocd_projects` variable, and apply the changes.
+
+2. Use the Argo CD web interface or edit the Application objects using K9s or `kubectl` and move each Application to the new project you created.
+
+3. Modify the module instantiations for each module and add the `argocd_project` variable to set the Application to use the new AppProject. 
+
+4. Run a `terraform apply` again. This time, the only changes you should see is the deletion of the old AppProjects.
 
 == Technical Documentation
 

--- a/bootstrap/locals.tf
+++ b/bootstrap/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  argocd_chart   = yamldecode(file("${path.module}/../charts/argocd/Chart.lock")).dependencies.0
   argocd_version = yamldecode(file("${path.module}/../chart-version.yaml")).appVersion
 
   jwt_token_payload = {

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,8 +1,3 @@
-locals {
-  argocd_chart = yamldecode(file("${path.module}/../charts/argocd/Chart.lock")).dependencies.0
-}
-
-# argocd secret key for token generation, it should be passed to next argocd generation
 resource "random_password" "argocd_server_secretkey" {
   length  = 32
   special = false
@@ -36,6 +31,42 @@ resource "helm_release" "argocd" {
   }
 }
 
+# TODO Consider chosing better names than control_plane and workers
+resource "argocd_project" "devops_stack_applications" {
+  for_each = var.argocd_projects
+
+  metadata {
+    name      = each.key
+    namespace = var.namespace
+    annotations = {
+      "devops-stack.io/argocd_namespace" = var.namespace
+    }
+  }
+
+  spec {
+    description  = "DevOps Stack applications in cluster ${each.value.destination_cluster}"
+    source_repos = each.value.allowed_source_repos
+
+    dynamic "destination" {
+      for_each = each.value.allowed_namespaces
+
+      content {
+        name      = each.value.destination_cluster
+        namespace = destination.value
+      }
+    }
+
+    orphaned_resources {
+      warn = true
+    }
+
+    cluster_resource_whitelist {
+      group = "*"
+      kind  = "*"
+    }
+  }
+}
+
 data "utils_deep_merge_yaml" "values" {
   input       = [for i in concat([local.helm_values.0.argo-cd], [var.helm_values.0.argo-cd]) : yamlencode(i)]
   append_list = true
@@ -44,5 +75,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "null_resource" "this" {
   depends_on = [
     resource.helm_release.argocd,
+    resource.random_password.argocd_server_secretkey,
+    resource.argocd_project.devops_stack_applications,
   ]
 }

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -8,6 +8,11 @@ output "argocd_namespace" {
   value       = helm_release.argocd.metadata.0.namespace
 }
 
+output "argocd_project_names" {
+  description = "The names of all the Argo CD AppProjects created by the bootstrap module."
+  value       = [for i in argocd_project.devops_stack_applications : i.metadata.0.name]
+}
+
 output "argocd_server_secretkey" {
   description = "The Argo CD server secret key."
   value       = random_password.argocd_server_secretkey.result

--- a/bootstrap/terraform.tf
+++ b/bootstrap/terraform.tf
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.9"
     }
+    argocd = {
+      source  = "oboukili/argocd"
+      version = ">= 6"
+    }
   }
   required_version = ">= 1.2"
 }

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -4,6 +4,27 @@ variable "namespace" {
   default     = "argocd"
 }
 
+variable "argocd_projects" {
+  description = <<-EOT
+    List of AppProject definitions to be created in Argo CD. By default, no projects are created since this variable defaults to an empty map.
+    
+    At a minimum, you need to provide the `destination_cluster` value, so that the destination cluster can be defined in the project. The name of the project is derived from the key of the map.
+
+    *The first cluster in the list should always be your main cluster where the Argo CD will be deployed, and the destination cluster for that project must be `in-cluster`.* 
+  EOT
+  type = map(object({
+    destination_cluster = string
+    allowed_source_repos        = optional(list(string), ["*"])
+    allowed_namespaces  = optional(list(string), ["*"])
+  }))
+  default = {}
+
+  validation {
+    condition     = length(keys(var.argocd_projects)) > 0 && values(var.argocd_projects)[0].destination_cluster == "in-cluster"
+    error_message = "The first AppProject definition provided must be for the cluster 'in-cluster'."
+  }
+}
+
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -13,9 +13,9 @@ variable "argocd_projects" {
     *The first cluster in the list should always be your main cluster where the Argo CD will be deployed, and the destination cluster for that project must be `in-cluster`.* 
   EOT
   type = map(object({
-    destination_cluster = string
-    allowed_source_repos        = optional(list(string), ["*"])
-    allowed_namespaces  = optional(list(string), ["*"])
+    destination_cluster  = string
+    allowed_source_repos = optional(list(string), ["*"])
+    allowed_namespaces   = optional(list(string), ["*"])
   }))
   default = {}
 

--- a/locals.tf
+++ b/locals.tf
@@ -213,7 +213,7 @@ locals {
           "oidc.config"                   = <<-EOT
             ${yamlencode(merge(var.oidc, { clientSecret = "$oidc.default.clientSecret" }))}
           EOT
-          "oidc.tls.insecure.skip.verify" = tostring(var.cluster_issuer == "ca-issuer" || var.cluster_issuer == "letsencrypt-staging")
+          "oidc.tls.insecure.skip.verify" = tostring(var.cluster_issuer != "letsencrypt-prod")
           "resource.customizations"       = <<-EOT
             argoproj.io/Application: # https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#argocd-app
               health.lua: |

--- a/locals.tf
+++ b/locals.tf
@@ -75,6 +75,9 @@ locals {
           name      = "kustomized-helm-cmp-tmp"
         }
       ]
+      # The extra containers of the repo_server pod must have resource requests/limits in order to allow this component 
+      # to autoscale properly.
+      resources = var.resources.repo_server # TODO Maybe this resources should be different from the repo_server one.
     },
     {
       name    = "helmfile-cmp"
@@ -101,6 +104,9 @@ locals {
           name      = "helmfile-cmp-tmp"
         }
       ]
+      # The extra containers of the repo_server pod must have resource requests/limits in order to allow this component 
+      # to autoscale properly.
+      resources = var.resources.repo_server # TODO Maybe this resources should be different from the repo_server one.
     }
   ]
 
@@ -154,7 +160,13 @@ locals {
           }, local.extra_accounts_tokens)
         }
       })
+      applicationSet = {
+        replicas  = var.high_availability.enabled ? var.high_availability.application_set.replicas : null
+        resources = var.resources.application_set
+      }
       controller = {
+        replicas  = var.high_availability.enabled ? var.high_availability.controller.replicas : null
+        resources = var.resources.controller
         metrics = {
           enabled = true
         }
@@ -163,6 +175,13 @@ locals {
         enabled = false
       }
       repoServer = {
+        replicas = var.high_availability.enabled && !var.high_availability.repo_server.autoscaling.enabled ? var.high_availability.server.replicas : null
+        autoscaling = var.high_availability.repo_server.autoscaling.enabled ? {
+          enabled     = true
+          minReplicas = var.high_availability.repo_server.autoscaling.min_replicas
+          maxReplicas = var.high_availability.repo_server.autoscaling.max_replicas
+        } : null
+        resources = var.resources.repo_server
         metrics = {
           enabled = true
         }
@@ -176,6 +195,13 @@ locals {
       }
       extraObjects = local.extra_objects
       server = {
+        replicas = var.high_availability.enabled && !var.high_availability.server.autoscaling.enabled ? var.high_availability.server.replicas : null
+        autoscaling = var.high_availability.server.autoscaling.enabled ? {
+          enabled     = true
+          minReplicas = var.high_availability.server.autoscaling.min_replicas
+          maxReplicas = var.high_availability.server.autoscaling.max_replicas
+        } : null
+        resources = var.resources.server
         extraArgs = [
           "--insecure",
         ]
@@ -237,6 +263,22 @@ locals {
         metrics = {
           enabled = true
         }
+      }
+      notifications = {
+        resources = var.resources.notifications
+      }
+      # When the Redis HA is enabled, the default Redis chart is not used, so we change the value to null.
+      redis = !var.high_availability.enabled ? {
+        resources = var.resources.redis
+      } : null
+      redis-ha = var.high_availability.enabled ? {
+        enabled = true
+        redis = {
+          resources = var.resources.redis
+        }
+        } : {
+        enabled = false
+        redis   = null
       }
     }
   }]

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = "argocd"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "argocd"
+      "cluster"     = "in-cluster"
+    }, var.argocd_labels)
   }
 
   wait    = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,8 @@ resource "random_uuid" "jti" {
 }
 
 resource "argocd_project" "this" {
+  count = var.argocd_project == null ? 1 : 0
+
   metadata {
     name      = "argocd"
     namespace = var.argocd_namespace
@@ -62,7 +64,7 @@ resource "argocd_application" "this" {
   cascade = false
 
   spec {
-    project = argocd_project.this.metadata.0.name
+    project = var.argocd_project == null ? argocd_project.this[0].metadata.0.name : var.argocd_project
 
     source {
       path            = "charts/argocd"

--- a/variables.tf
+++ b/variables.tf
@@ -37,9 +37,9 @@ variable "target_revision" {
 }
 
 variable "cluster_issuer" {
-  description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files."
+  description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files. You can use `ca-issuer` when using the self-signed variant of cert-manager."
   type        = string
-  default     = "ca-issuer"
+  default     = "selfsigned-issuer"
 }
 
 variable "namespace" {
@@ -214,6 +214,7 @@ variable "oidc" {
   description = "OIDC settings for the log in to the Argo CD web interface."
   type        = any
   default     = null
+  # TODO Add proper OIDC variable here!
 }
 
 variable "rbac" {

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,13 @@ variable "repositories" {
 }
 
 variable "ssh_known_hosts" {
-  description = "List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value. **If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here.**"
+  description = <<-EOT
+    List of SSH known hosts to add to Argo CD.
+    
+    Check the official `values.yaml` to get the format to pass this value. 
+    
+    IMPORTANT: If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here."
+  EOT
   type        = string
   default     = null
 }
@@ -165,7 +171,7 @@ variable "helmfile_cmp_version" {
 }
 
 variable "helmfile_cmp_env_variables" {
-  description = "List of environment variables to attach to the helmfile-cmp plugin, usually used to pass authentication credentials. Use a an https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[explicit format] or take the values from a https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data[Kubernetes secret]."
+  description = "List of environment variables to attach to the helmfile-cmp plugin, usually used to pass authentication credentials. Use an https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[explicit format] or take the values from a https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data[Kubernetes secret]."
   type = list(object({
     name  = optional(string)
     value = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,139 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
+variable "resources" {
+  description = <<-EOT
+    Resource limits and requests for the Argo CD components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+    NOTE: The `repo_server` requests and limits will be applied to all the extra containers that are deployed with the `argocd-repo-server` component (each container has the same requests and limits as the main container, **so it is cumulative**).
+
+    NOTE: If you enable the HA mode using the `high_availability` variable, the values for Redis will be applied to the Redis HA chart instead of the default one.
+  EOT
+  type = object({
+
+    application_set = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "500m")
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    notifications = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    repo_server = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    server = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    redis = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "64Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "300m")
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+  default = {}
+}
+
+variable "high_availability" {
+  description = <<-EOT
+    Argo CD High Availability settings. By default, the HA is disabled.
+
+    To enable HA using the default replicas, simply set the value `high_availability.enabled` to `true`. **This will deploy Argo CD in HA without autoscaling.**
+
+    You can enable autoscaling of the `argocd-server` and `argocd-repo-server` components by setting the `high_availability.server.autoscaling.enabled` and `high_availability.repo_server.autoscaling.enabled` values to `true`. You can also configure the minimum and maximum replicas desired or leave the default values.
+
+    IMPORTANT: Activating the HA mode automatically enables the Redis HA chart which requires at least 3 worker nodes, as this chart enforces Pods to run on separate nodes.
+
+    NOTE: Since this variable uses the `optional` argument to forcing the user to define all the values, there is a side effect you can pass any other bogus value and Terraform will accept it, **but they won't be used in the chart behind the module**.
+  EOT
+
+  type = object({
+    enabled = bool
+
+    controller = optional(object({
+      replicas = optional(number, 1)
+    }), {})
+
+    application_set = optional(object({
+      replicas = optional(number, 2)
+    }), {})
+
+    server = optional(object({
+      replicas = optional(number, 2)
+      autoscaling = optional(object({
+        enabled      = bool
+        min_replicas = optional(number, 2)
+        max_replicas = optional(number, 5)
+        }), {
+        enabled = false
+      })
+    }), {})
+
+    repo_server = optional(object({
+      replicas = optional(number, 2)
+      autoscaling = optional(object({
+        enabled      = bool
+        min_replicas = optional(number, 2)
+        max_replicas = optional(number, 5)
+        }), {
+        enabled = false
+      })
+    }), {})
+
+  })
+
+  default = {
+    enabled = false
+  }
+}
+
 variable "oidc" {
   description = "OIDC settings for the log in to the Argo CD web interface."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR is still related to the preparation for the centralized Argo CD model. It does the following:

- Adds support to create an AppProject inside the bootstrap module that can then be used by the other DevOps Stack modules, including the final Argo CD.
- Like on other modules, adds labels to the Argo CD application to better organize it on the web UI.
- Adds a new variable `high_availability` to enable the HA mode of Argo CD. _The behavior of this variable is better described on its description_.
- Adds a new variable `resources` to set requests and limits for the components of Argo CD:
   - We discussed that this could be added in a separate PR, but I was required to add it here because the Horizontal Pod Autoscaler requires requests to know if it needs to scale up or down a pod (this is relevant for the `argocd-repor-server` and/or `argocd-server` when using the autoscaling HA mode);
   - The default values are the ones that are commented on the Helm chart of Argo CD but I had to increase some because I found out that they were to small for some of the components;
   - I added the same limits/requests as the `repo_server` to the Custom Management Plugins that we deploy with it, otherwise the Horizontal Pod Autoscaler would not work for the `repo_server`. I do not know if these sidecars require all that much horsepower and maybe we should either hard code some reasonable values for these sidecars or add a variable to set them aside.  

:warning: **Do a _Rebase and merge_**.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)
- [x] SKS (Exoscale)