### PR TITLE
fix(bootstrap): fix the validation of `argocd_projects` when nothing is passed

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -223,17 +223,17 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
+- [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
+
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -288,21 +288,37 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.4.0"`
+Default: `"v3.5.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
-Description: SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
+Description: SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files. You can use `ca-issuer` when using the self-signed variant of cert-manager.
 
 Type: `string`
 
-Default: `"ca-issuer"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -352,6 +368,149 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for the Argo CD components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+NOTE: The `repo_server` requests and limits will be applied to all the extra containers that are deployed with the `argocd-repo-server` component (each container has the same requests and limits as the main container, **so it is cumulative**).
+
+NOTE: If you enable the HA mode using the `high_availability` variable, the values for Redis will be applied to the Redis HA chart instead of the default one.
+
+Type:
+[source,hcl]
+----
+object({
+
+    application_set = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "500m")
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    notifications = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    repo_server = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    server = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    redis = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "64Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "300m")
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
+==== [[input_high_availability]] <<input_high_availability,high_availability>>
+
+Description: Argo CD High Availability settings. By default, the HA is disabled.
+
+To enable HA using the default replicas, simply set the value `high_availability.enabled` to `true`. **This will deploy Argo CD in HA without autoscaling.**
+
+You can enable autoscaling of the `argocd-server` and `argocd-repo-server` components by setting the `high_availability.server.autoscaling.enabled` and `high_availability.repo_server.autoscaling.enabled` values to `true`. You can also configure the minimum and maximum replicas desired or leave the default values.
+
+IMPORTANT: Activating the HA mode automatically enables the Redis HA chart which requires at least 3 worker nodes, as this chart enforces Pods to run on separate nodes.
+
+NOTE: Since this variable uses the `optional` argument to forcing the user to define all the values, there is a side effect you can pass any other bogus value and Terraform will accept it, **but they won't be used in the chart behind the module**.
+
+Type:
+[source,hcl]
+----
+object({
+    enabled = bool
+
+    controller = optional(object({
+      replicas = optional(number, 1)
+    }), {})
+
+    application_set = optional(object({
+      replicas = optional(number, 2)
+    }), {})
+
+    server = optional(object({
+      replicas = optional(number, 2)
+      autoscaling = optional(object({
+        enabled      = bool
+        min_replicas = optional(number, 2)
+        max_replicas = optional(number, 5)
+        }), {
+        enabled = false
+      })
+    }), {})
+
+    repo_server = optional(object({
+      replicas = optional(number, 2)
+      autoscaling = optional(object({
+        enabled      = bool
+        min_replicas = optional(number, 2)
+        max_replicas = optional(number, 5)
+        }), {
+        enabled = false
+      })
+    }), {})
+
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "enabled": false
+}
+----
+
 ==== [[input_oidc]] <<input_oidc,oidc>>
 
 Description: OIDC settings for the log in to the Argo CD web interface.
@@ -391,7 +550,11 @@ Default: `{}`
 
 ==== [[input_ssh_known_hosts]] <<input_ssh_known_hosts,ssh_known_hosts>>
 
-Description: List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value. **If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here.**
+Description: List of SSH known hosts to add to Argo CD.  
+
+Check the official `values.yaml` to get the format to pass this value.   
+
+IMPORTANT: If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here."
 
 Type: `string`
 
@@ -455,7 +618,7 @@ Default: `"0.1.1"`
 
 ==== [[input_helmfile_cmp_env_variables]] <<input_helmfile_cmp_env_variables,helmfile_cmp_env_variables>>
 
-Description: List of environment variables to attach to the helmfile-cmp plugin, usually used to pass authentication credentials. Use a an https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[explicit format] or take the values from a https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data[Kubernetes secret].
+Description: List of environment variables to attach to the helmfile-cmp plugin, usually used to pass authentication credentials. Use an https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[explicit format] or take the values from a https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data[Kubernetes secret].
 
 Type:
 [source,hcl]
@@ -513,12 +676,12 @@ Description: Map of extra accounts that were created and their tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -559,16 +722,28 @@ Description: Map of extra accounts that were created and their tokens.
 |`"argocd"`
 |no
 
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.4.0"`
+|`"v3.5.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
-|SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
+|SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files. You can use `ca-issuer` when using the self-signed variant of cert-manager.
 |`string`
-|`"ca-issuer"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -615,6 +790,153 @@ object({
 |`{}`
 |no
 
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for the Argo CD components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+NOTE: The `repo_server` requests and limits will be applied to all the extra containers that are deployed with the `argocd-repo-server` component (each container has the same requests and limits as the main container, **so it is cumulative**).
+
+NOTE: If you enable the HA mode using the `high_availability` variable, the values for Redis will be applied to the Redis HA chart instead of the default one.
+
+|
+
+[source]
+----
+object({
+
+    application_set = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "500m")
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    notifications = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    repo_server = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    server = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    redis = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "64Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "300m")
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+|`{}`
+|no
+
+|[[input_high_availability]] <<input_high_availability,high_availability>>
+|Argo CD High Availability settings. By default, the HA is disabled.
+
+To enable HA using the default replicas, simply set the value `high_availability.enabled` to `true`. **This will deploy Argo CD in HA without autoscaling.**
+
+You can enable autoscaling of the `argocd-server` and `argocd-repo-server` components by setting the `high_availability.server.autoscaling.enabled` and `high_availability.repo_server.autoscaling.enabled` values to `true`. You can also configure the minimum and maximum replicas desired or leave the default values.
+
+IMPORTANT: Activating the HA mode automatically enables the Redis HA chart which requires at least 3 worker nodes, as this chart enforces Pods to run on separate nodes.
+
+NOTE: Since this variable uses the `optional` argument to forcing the user to define all the values, there is a side effect you can pass any other bogus value and Terraform will accept it, **but they won't be used in the chart behind the module**.
+
+|
+
+[source]
+----
+object({
+    enabled = bool
+
+    controller = optional(object({
+      replicas = optional(number, 1)
+    }), {})
+
+    application_set = optional(object({
+      replicas = optional(number, 2)
+    }), {})
+
+    server = optional(object({
+      replicas = optional(number, 2)
+      autoscaling = optional(object({
+        enabled      = bool
+        min_replicas = optional(number, 2)
+        max_replicas = optional(number, 5)
+        }), {
+        enabled = false
+      })
+    }), {})
+
+    repo_server = optional(object({
+      replicas = optional(number, 2)
+      autoscaling = optional(object({
+        enabled      = bool
+        min_replicas = optional(number, 2)
+        max_replicas = optional(number, 5)
+        }), {
+        enabled = false
+      })
+    }), {})
+
+  })
+----
+
+|
+
+[source]
+----
+{
+  "enabled": false
+}
+----
+
+|no
+
 |[[input_oidc]] <<input_oidc,oidc>>
 |OIDC settings for the log in to the Argo CD web interface.
 |`any`
@@ -649,7 +971,12 @@ object({
 |no
 
 |[[input_ssh_known_hosts]] <<input_ssh_known_hosts,ssh_known_hosts>>
-|List of SSH known hosts to add to Argo CD. Check the official `values.yaml` to get the format to pass this value. **If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here.**
+|List of SSH known hosts to add to Argo CD.
+    
+Check the official `values.yaml` to get the format to pass this value.
+    
+IMPORTANT: If you set this variable, the default known hosts will be overridden by this value, so you might want to consider adding the ones you need here."
+
 |`string`
 |`null`
 |no
@@ -709,7 +1036,7 @@ object({
 |no
 
 |[[input_helmfile_cmp_env_variables]] <<input_helmfile_cmp_env_variables,helmfile_cmp_env_variables>>
-|List of environment variables to attach to the helmfile-cmp plugin, usually used to pass authentication credentials. Use a an https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[explicit format] or take the values from a https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data[Kubernetes secret].
+|List of environment variables to attach to the helmfile-cmp plugin, usually used to pass authentication credentials. Use an https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[explicit format] or take the values from a https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data[Kubernetes secret].
 |
 
 [source]

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -63,6 +63,8 @@ The following requirements are needed by this module:
 
 - [[requirement_terraform]] <<requirement_terraform,terraform>> (>= 1.2)
 
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 6)
+
 - [[requirement_helm]] <<requirement_helm,helm>> (>= 2)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
@@ -79,13 +81,15 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
 
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
@@ -95,6 +99,7 @@ The following providers are used by this module:
 
 The following resources are used by this module:
 
+- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.devops_stack_applications] (resource)
 - https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release[helm_release.argocd] (resource)
 - https://registry.terraform.io/providers/camptocamp/jwt/latest/docs/resources/hashed_token[jwt_hashed_token.argocd] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
@@ -114,6 +119,26 @@ Description: Namespace where to deploy Argo CD.
 Type: `string`
 
 Default: `"argocd"`
+
+==== [[input_argocd_projects]] <<input_argocd_projects,argocd_projects>>
+
+Description: List of AppProject definitions to be created in Argo CD. By default, no projects are created since this variable defaults to an empty map.  
+
+At a minimum, you need to provide the `destination_cluster` value, so that the destination cluster can be defined in the project. The name of the project is derived from the key of the map.
+
+*The first cluster in the list should always be your main cluster where the Argo CD will be deployed, and the destination cluster for that project must be `in-cluster`.*
+
+Type:
+[source,hcl]
+----
+map(object({
+    destination_cluster  = string
+    allowed_source_repos = optional(list(string), ["*"])
+    allowed_namespaces   = optional(list(string), ["*"])
+  }))
+----
+
+Default: `{}`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -143,6 +168,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 
 Description: The namespace where to deploy Argo CD.
 
+==== [[output_argocd_project_names]] <<output_argocd_project_names,argocd_project_names>>
+
+Description: The names of all the Argo CD AppProjects created by the bootstrap module.
+
 ==== [[output_argocd_server_secretkey]] <<output_argocd_server_secretkey,argocd_server_secretkey>>
 
 Description: The Argo CD server secret key.
@@ -168,6 +197,7 @@ Description: The Argo CD accounts pipeline tokens.
 |===
 |Name |Version
 |[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 1.2
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 6
 |[[requirement_helm]] <<requirement_helm,helm>> |>= 2
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_jwt]] <<requirement_jwt,jwt>> |>= 1.1
@@ -185,6 +215,7 @@ Description: The Argo CD accounts pipeline tokens.
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_null]] <<provider_null,null>> |n/a
 |===
@@ -194,6 +225,7 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Type
+|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.devops_stack_applications] |resource
 |https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release[helm_release.argocd] |resource
 |https://registry.terraform.io/providers/camptocamp/jwt/latest/docs/resources/hashed_token[jwt_hashed_token.argocd] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
@@ -212,6 +244,27 @@ Description: The Argo CD accounts pipeline tokens.
 |Namespace where to deploy Argo CD.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_projects]] <<input_argocd_projects,argocd_projects>>
+|List of AppProject definitions to be created in Argo CD. By default, no projects are created since this variable defaults to an empty map.
+    
+At a minimum, you need to provide the `destination_cluster` value, so that the destination cluster can be defined in the project. The name of the project is derived from the key of the map.
+
+*The first cluster in the list should always be your main cluster where the Argo CD will be deployed, and the destination cluster for that project must be `in-cluster`.*
+
+|
+
+[source]
+----
+map(object({
+    destination_cluster  = string
+    allowed_source_repos = optional(list(string), ["*"])
+    allowed_namespaces   = optional(list(string), ["*"])
+  }))
+----
+
+|`{}`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
@@ -239,6 +292,7 @@ Description: The Argo CD accounts pipeline tokens.
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
 |[[output_argocd_namespace]] <<output_argocd_namespace,argocd_namespace>> |The namespace where to deploy Argo CD.
+|[[output_argocd_project_names]] <<output_argocd_project_names,argocd_project_names>> |The names of all the Argo CD AppProjects created by the bootstrap module.
 |[[output_argocd_server_secretkey]] <<output_argocd_server_secretkey,argocd_server_secretkey>> |The Argo CD server secret key.
 |[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in `ARGOCD_AUTH_TOKEN` environment variable. May be used for configuring Argo CD Terraform provider.
 |[[output_argocd_accounts_pipeline_tokens]] <<output_argocd_accounts_pipeline_tokens,argocd_accounts_pipeline_tokens>> |The Argo CD accounts pipeline tokens.

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -20,7 +20,7 @@ variable "argocd_projects" {
   default = {}
 
   validation {
-    condition     = length(keys(var.argocd_projects)) > 0 && values(var.argocd_projects)[0].destination_cluster == "in-cluster"
+    condition     = length(keys(var.argocd_projects)) > 0 ? values(var.argocd_projects)[0].destination_cluster == "in-cluster" : true
     error_message = "The first AppProject definition provided must be for the cluster 'in-cluster'."
   }
 }


### PR DESCRIPTION
## Description of the changes

The previous release has an issue with the bootstrap variant that prevents the instatiation of the module when that variable `argocd_projects` is not defined.

This PR modifies the validation condition to always return `true` when the variable is not defined in the instantiation.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
