### PR TITLE
fix: add ServiceMonitors to fix missing metrics on Prometheus and adjust default resources requests/limits

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -394,12 +394,12 @@ object({
 
     controller = optional(object({
       requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
         cpu    = optional(string, "500m")
         memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "1")
+        memory = optional(string, "2Gi")
       }), {})
     }), {})
 
@@ -416,11 +416,11 @@ object({
 
     repo_server = optional(object({
       requests = optional(object({
-        cpu    = optional(string, "50m")
+        cpu    = optional(string, "200m")
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
+        cpu    = optional(string, "400m")
         memory = optional(string, "256Mi")
       }), {})
     }), {})
@@ -676,12 +676,12 @@ Description: Map of extra accounts that were created and their tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -816,12 +816,12 @@ object({
 
     controller = optional(object({
       requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
         cpu    = optional(string, "500m")
         memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "1")
+        memory = optional(string, "2Gi")
       }), {})
     }), {})
 
@@ -838,11 +838,11 @@ object({
 
     repo_server = optional(object({
       requests = optional(object({
-        cpu    = optional(string, "50m")
+        cpu    = optional(string, "200m")
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
+        cpu    = optional(string, "400m")
         memory = optional(string, "256Mi")
       }), {})
     }), {})

--- a/README.adoc
+++ b/README.adoc
@@ -223,6 +223,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -232,8 +234,6 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.5.0"`
+Default: `"v3.5.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -737,7 +737,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.5.0"`
+|`"v3.5.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ The Argo CD chart used by this module is shipped in this repository as well, in 
 
 == Usage
 
-IMPORTANT: The root of this repository contains the final Argo CD module to be deployed, which uses a [Terraform provider for Argo CD] to deploy the Argo CD chart. On the first deployment of a cluster, you'll want to use the bootstrap module instead. Check the xref:ROOT:bootstrap/README.adoc[bootstrap module's documentation] for more information.
+IMPORTANT: The root of this repository contains the final Argo CD module to be deployed, which uses a https://registry.terraform.io/providers/oboukili/argocd/latest/docs[Terraform provider for Argo CD] to deploy the Argo CD chart. On the first deployment of a cluster, you'll want to use the bootstrap module instead. Check the xref:ROOT:bootstrap/README.adoc[bootstrap module's documentation] for more information.
 
 To deploy the final Argo CD module, you'll need to add the following declaration on your Terraform configuration:
 

--- a/locals.tf
+++ b/locals.tf
@@ -169,6 +169,9 @@ locals {
         resources = var.resources.controller
         metrics = {
           enabled = true
+          serviceMonitor = {
+            enabled = true
+          }
         }
       }
       dex = {
@@ -184,6 +187,9 @@ locals {
         resources = var.resources.repo_server
         metrics = {
           enabled = true
+          serviceMonitor = {
+            enabled = true
+          }
         }
         volumes         = local.repo_server_volumes
         extraContainers = local.repo_server_extra_containers
@@ -262,6 +268,9 @@ locals {
         }
         metrics = {
           enabled = true
+          serviceMonitor = {
+            enabled = true
+          }
         }
       }
       notifications = {

--- a/variables.tf
+++ b/variables.tf
@@ -100,12 +100,12 @@ variable "resources" {
 
     controller = optional(object({
       requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
         cpu    = optional(string, "500m")
         memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string, "1")
+        memory = optional(string, "2Gi")
       }), {})
     }), {})
 
@@ -122,11 +122,11 @@ variable "resources" {
 
     repo_server = optional(object({
       requests = optional(object({
-        cpu    = optional(string, "50m")
+        cpu    = optional(string, "200m")
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
+        cpu    = optional(string, "400m")
         memory = optional(string, "256Mi")
       }), {})
     }), {})


### PR DESCRIPTION
## Description of the changes

This fixes the missing metrics on the Argo CD dashboard that we deploy by default for Grafana.

I also increased the limits/requests for the Application Controller and Repo Server components, since they were always breaking (OOMKilled or simply CPU throttling), even on a barebones cluster.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
