### PR TITLE
fix!: change the default cluster issuer, remove the namespace variable and hardcode the Helm release name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -223,8 +223,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -234,6 +232,8 @@ The following providers are used by this module:
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -280,14 +280,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created. Normally, it should take the outputof the namespace from the bootstrap module.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -310,7 +302,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.5.1"`
+Default: `"v3.5.2"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -319,14 +311,6 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 Type: `string`
 
 Default: `"selfsigned-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where to deploy Argo CD.
-
-Type: `string`
-
-Default: `"argocd"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -716,12 +700,6 @@ Description: Map of extra accounts that were created and their tokens.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created. Normally, it should take the outputof the namespace from the bootstrap module.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -737,19 +715,13 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.5.1"`
+|`"v3.5.2"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files. You can use `ca-issuer` when using the self-signed variant of cert-manager.
 |`string`
 |`"selfsigned-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where to deploy Argo CD.
-|`string`
-|`"argocd"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -112,14 +112,6 @@ The following resources are used by this module:
 
 The following input variables are optional (have default values):
 
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where to deploy Argo CD.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_projects]] <<input_argocd_projects,argocd_projects>>
 
 Description: List of AppProject definitions to be created in Argo CD. By default, no projects are created since this variable defaults to an empty map.  
@@ -166,7 +158,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 
 ==== [[output_argocd_namespace]] <<output_argocd_namespace,argocd_namespace>>
 
-Description: The namespace where to deploy Argo CD.
+Description: The namespace where Argo CD resides. The main use of this output is to create an implicit dependency when passing this attribute to the oboukili/argocd provider settings.
 
 ==== [[output_argocd_project_names]] <<output_argocd_project_names,argocd_project_names>>
 
@@ -211,9 +203,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
@@ -240,12 +232,6 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where to deploy Argo CD.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_projects]] <<input_argocd_projects,argocd_projects>>
 |List of AppProject definitions to be created in Argo CD. By default, no projects are created since this variable defaults to an empty map.
     
@@ -291,7 +277,7 @@ map(object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_argocd_namespace]] <<output_argocd_namespace,argocd_namespace>> |The namespace where to deploy Argo CD.
+|[[output_argocd_namespace]] <<output_argocd_namespace,argocd_namespace>> |The namespace where Argo CD resides. The main use of this output is to create an implicit dependency when passing this attribute to the oboukili/argocd provider settings.
 |[[output_argocd_project_names]] <<output_argocd_project_names,argocd_project_names>> |The names of all the Argo CD AppProjects created by the bootstrap module.
 |[[output_argocd_server_secretkey]] <<output_argocd_server_secretkey,argocd_server_secretkey>> |The Argo CD server secret key.
 |[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in `ARGOCD_AUTH_TOKEN` environment variable. May be used for configuring Argo CD Terraform provider.

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -20,7 +20,7 @@ resource "helm_release" "argocd" {
   chart      = local.argocd_chart.name
   version    = local.argocd_chart.version
 
-  namespace         = var.namespace
+  namespace         = "argocd"
   dependency_update = true
   create_namespace  = true
   timeout           = 10800
@@ -31,16 +31,12 @@ resource "helm_release" "argocd" {
   }
 }
 
-# TODO Consider chosing better names than control_plane and workers
 resource "argocd_project" "devops_stack_applications" {
   for_each = var.argocd_projects
 
   metadata {
     name      = each.key
-    namespace = var.namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.namespace
-    }
+    namespace = "argocd"
   }
 
   spec {

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -4,7 +4,7 @@ output "id" {
 }
 
 output "argocd_namespace" {
-  description = "The namespace where to deploy Argo CD."
+  description = "The namespace where Argo CD resides. The main use of this output is to create an implicit dependency when passing this attribute to the oboukili/argocd provider settings."
   value       = helm_release.argocd.metadata.0.namespace
 }
 

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,9 +1,3 @@
-variable "namespace" {
-  description = "Namespace where to deploy Argo CD."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_projects" {
   description = <<-EOT
     List of AppProject definitions to be created in Argo CD. By default, no projects are created since this variable defaults to an empty map.

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,8 @@ resource "argocd_application" "this" {
       repo_url        = "https://github.com/camptocamp/devops-stack-module-argocd.git"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "argocd"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 

--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = "argocd"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -57,7 +54,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = "argocd"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "argocd"
       "cluster"     = "in-cluster"

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = "in-cluster"
-      namespace = var.namespace
+      namespace = "argocd"
     }
 
     orphaned_resources {
@@ -82,7 +82,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = "in-cluster"
-      namespace = var.namespace
+      namespace = "argocd"
     }
 
     sync_policy {

--- a/variables.tf
+++ b/variables.tf
@@ -42,12 +42,6 @@ variable "cluster_issuer" {
   default     = "selfsigned-issuer"
 }
 
-variable "namespace" {
-  description = "Namespace where to deploy Argo CD."
-  type        = string
-  default     = "argocd"
-}
-
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -12,12 +12,6 @@ variable "base_domain" {
   type        = string
 }
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created. Normally, it should take the outputof the namespace from the bootstrap module."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string


### PR DESCRIPTION
Three commits compose this PR:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)