### PR TITLE
fix: adjust the resources and remove default limits

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -670,12 +670,12 @@ Description: Map of extra accounts that were created and their tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -231,9 +231,9 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.3.0"`
+Default: `"v4.4.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -362,11 +362,13 @@ Default: `{}`
 
 ==== [[input_resources]] <<input_resources,resources>>
 
-Description: Resource limits and requests for the Argo CD components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+Description: Resource limits and requests for Argo CD's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
 
 NOTE: The `repo_server` requests and limits will be applied to all the extra containers that are deployed with the `argocd-repo-server` component (each container has the same requests and limits as the main container, **so it is cumulative**).
 
 NOTE: If you enable the HA mode using the `high_availability` variable, the values for Redis will be applied to the Redis HA chart instead of the default one.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
 
 Type:
 [source,hcl]
@@ -379,8 +381,8 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
-        memory = optional(string, "128Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -390,8 +392,8 @@ object({
         memory = optional(string, "512Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "1")
-        memory = optional(string, "2Gi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -401,8 +403,8 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "200m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -412,8 +414,8 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "400m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -423,19 +425,19 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
     redis = optional(object({
       requests = optional(object({
         cpu    = optional(string, "200m")
-        memory = optional(string, "64Mi")
+        memory = optional(string, "256Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "300m")
-        memory = optional(string, "128Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -729,7 +731,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.3.0"`
+|`"v4.4.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -777,11 +779,13 @@ object({
 |no
 
 |[[input_resources]] <<input_resources,resources>>
-|Resource limits and requests for the Argo CD components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+|Resource limits and requests for Argo CD's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
 
 NOTE: The `repo_server` requests and limits will be applied to all the extra containers that are deployed with the `argocd-repo-server` component (each container has the same requests and limits as the main container, **so it is cumulative**).
 
 NOTE: If you enable the HA mode using the `high_availability` variable, the values for Redis will be applied to the Redis HA chart instead of the default one.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
 
 |
 
@@ -795,8 +799,8 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
-        memory = optional(string, "128Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -806,8 +810,8 @@ object({
         memory = optional(string, "512Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "1")
-        memory = optional(string, "2Gi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -817,8 +821,8 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "200m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -828,8 +832,8 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "400m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -839,19 +843,19 @@ object({
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
     redis = optional(object({
       requests = optional(object({
         cpu    = optional(string, "200m")
-        memory = optional(string, "64Mi")
+        memory = optional(string, "256Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "300m")
-        memory = optional(string, "128Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -79,11 +79,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
 
@@ -201,9 +201,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -79,11 +79,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
-
-- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
 
@@ -201,9 +201,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6

--- a/locals.tf
+++ b/locals.tf
@@ -140,8 +140,6 @@ locals {
     var.repo_server_azure_workload_identity_clientid != null ? { "azure.workload.identity/client-id" = var.repo_server_azure_workload_identity_clientid } : {}
   )
 
-  repo_server_service_account_labels = var.repo_server_azure_workload_identity_clientid != null ? { "azure.workload.identity/use" : "true" } : {}
-
   repo_server_pod_labels = merge(
     var.repo_server_azure_workload_identity_clientid != null ? { "azure.workload.identity/use" : "true" } : {},
     var.repo_server_aadpodidbinding != null ? { "aadpodidbinding" : var.repo_server_aadpodidbinding } : {}
@@ -213,7 +211,6 @@ locals {
         podLabels       = local.repo_server_pod_labels
         serviceAccount = {
           annotations = local.repo_server_service_account_annotations
-          labels      = local.repo_server_service_account_labels
         }
       }
       extraObjects = local.extra_objects

--- a/locals.tf
+++ b/locals.tf
@@ -78,7 +78,10 @@ locals {
       ]
       # The extra containers of the repo_server pod must have resource requests/limits in order to allow this component
       # to autoscale properly.
-      resources = var.resources.repo_server # TODO Maybe this resources should be different from the repo_server one.
+      resources = { # TODO Maybe these resources should be different from the repo_server one.
+        requests = { for k, v in var.resources.repo_server.requests : k => v if v != null }
+        limits   = { for k, v in var.resources.repo_server.limits : k => v if v != null }
+      }
     },
     {
       name    = "helmfile-cmp"
@@ -108,7 +111,10 @@ locals {
       ]
       # The extra containers of the repo_server pod must have resource requests/limits in order to allow this component
       # to autoscale properly.
-      resources = var.resources.repo_server # TODO Maybe this resources should be different from the repo_server one.
+      resources = { # TODO Maybe these resources should be different from the repo_server one.
+        requests = { for k, v in var.resources.repo_server.requests : k => v if v != null }
+        limits   = { for k, v in var.resources.repo_server.limits : k => v if v != null }
+      }
     }
   ]
 
@@ -163,12 +169,18 @@ locals {
         }
       })
       applicationSet = {
-        replicas  = var.high_availability.enabled ? var.high_availability.application_set.replicas : null
-        resources = var.resources.application_set
+        replicas = var.high_availability.enabled ? var.high_availability.application_set.replicas : null
+        resources = {
+          requests = { for k, v in var.resources.application_set.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.application_set.limits : k => v if v != null }
+        }
       }
       controller = {
-        replicas  = var.high_availability.enabled ? var.high_availability.controller.replicas : null
-        resources = var.resources.controller
+        replicas = var.high_availability.enabled ? var.high_availability.controller.replicas : null
+        resources = {
+          requests = { for k, v in var.resources.controller.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.controller.limits : k => v if v != null }
+        }
         metrics = {
           enabled = true
           serviceMonitor = {
@@ -186,7 +198,10 @@ locals {
           minReplicas = var.high_availability.repo_server.autoscaling.min_replicas
           maxReplicas = var.high_availability.repo_server.autoscaling.max_replicas
         } : null
-        resources = var.resources.repo_server
+        resources = {
+          requests = { for k, v in var.resources.repo_server.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.repo_server.limits : k => v if v != null }
+        }
         metrics = {
           enabled = true
           serviceMonitor = {
@@ -209,7 +224,10 @@ locals {
           minReplicas = var.high_availability.server.autoscaling.min_replicas
           maxReplicas = var.high_availability.server.autoscaling.max_replicas
         } : null
-        resources = var.resources.server
+        resources = {
+          requests = { for k, v in var.resources.server.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.server.limits : k => v if v != null }
+        }
         extraArgs = [
           "--insecure",
         ]
@@ -273,16 +291,25 @@ locals {
         }
       }
       notifications = {
-        resources = var.resources.notifications
+        resources = {
+          requests = { for k, v in var.resources.notifications.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.notifications.limits : k => v if v != null }
+        }
       }
       # When the Redis HA is enabled, the default Redis chart is not used, so we change the value to null.
       redis = !var.high_availability.enabled ? {
-        resources = var.resources.redis
+        resources = {
+          requests = { for k, v in var.resources.redis.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.redis.limits : k => v if v != null }
+        }
       } : null
       redis-ha = var.high_availability.enabled ? {
         enabled = true
         redis = {
-          resources = var.resources.redis
+          resources = {
+            requests = { for k, v in var.resources.redis.requests : k => v if v != null }
+            limits   = { for k, v in var.resources.redis.limits : k => v if v != null }
+          }
         }
         } : {
         enabled = false

--- a/variables.tf
+++ b/variables.tf
@@ -74,11 +74,13 @@ variable "dependency_ids" {
 
 variable "resources" {
   description = <<-EOT
-    Resource limits and requests for the Argo CD components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+    Resource limits and requests for Argo CD's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
 
     NOTE: The `repo_server` requests and limits will be applied to all the extra containers that are deployed with the `argocd-repo-server` component (each container has the same requests and limits as the main container, **so it is cumulative**).
 
     NOTE: If you enable the HA mode using the `high_availability` variable, the values for Redis will be applied to the Redis HA chart instead of the default one.
+
+    IMPORTANT: These are not production values. You should always adjust them to your needs.
   EOT
   type = object({
 
@@ -88,8 +90,8 @@ variable "resources" {
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
-        memory = optional(string, "128Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -99,8 +101,8 @@ variable "resources" {
         memory = optional(string, "512Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "1")
-        memory = optional(string, "2Gi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -110,8 +112,8 @@ variable "resources" {
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "200m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -121,8 +123,8 @@ variable "resources" {
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "400m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
@@ -132,19 +134,19 @@ variable "resources" {
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "100m")
-        memory = optional(string, "256Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 
     redis = optional(object({
       requests = optional(object({
         cpu    = optional(string, "200m")
-        memory = optional(string, "64Mi")
+        memory = optional(string, "256Mi")
       }), {})
       limits = optional(object({
-        cpu    = optional(string, "300m")
-        memory = optional(string, "128Mi")
+        cpu    = optional(string)
+        memory = optional(string)
       }), {})
     }), {})
 


### PR DESCRIPTION
## Description of the changes

We found that having limits by default on Argo CD could potentially break a bootstrap of clusters with a lot of Applications and/or ApplicationSets and then it was really difficult to increase the limits while Argo CD was hanging and starving for resources.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)