### PR TITLE
feat: add variables to set resource requests/limits on plugins

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.4.0"`
+Default: `"v4.4.1"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -411,6 +411,28 @@ object({
     repo_server = optional(object({
       requests = optional(object({
         cpu    = optional(string, "200m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }), {})
+    }), {})
+
+    kustomized_helm_cmp = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }), {})
+    }), {})
+
+    helmfile_cmp = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({
@@ -674,8 +696,8 @@ Description: Map of extra accounts that were created and their tokens.
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |===
 
 = Resources
@@ -731,7 +753,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.4.0"`
+|`"v4.4.1"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -829,6 +851,28 @@ object({
     repo_server = optional(object({
       requests = optional(object({
         cpu    = optional(string, "200m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }), {})
+    }), {})
+
+    kustomized_helm_cmp = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }), {})
+    }), {})
+
+    helmfile_cmp = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
         memory = optional(string, "128Mi")
       }), {})
       limits = optional(object({

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -79,11 +79,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
+
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
 
@@ -201,9 +201,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6

--- a/locals.tf
+++ b/locals.tf
@@ -78,9 +78,9 @@ locals {
       ]
       # The extra containers of the repo_server pod must have resource requests/limits in order to allow this component
       # to autoscale properly.
-      resources = { # TODO Maybe these resources should be different from the repo_server one.
-        requests = { for k, v in var.resources.repo_server.requests : k => v if v != null }
-        limits   = { for k, v in var.resources.repo_server.limits : k => v if v != null }
+      resources = {
+        requests = { for k, v in var.resources.kustomized_helm_cmp.requests : k => v if v != null }
+        limits   = { for k, v in var.resources.kustomized_helm_cmp.limits : k => v if v != null }
       }
     },
     {
@@ -111,9 +111,9 @@ locals {
       ]
       # The extra containers of the repo_server pod must have resource requests/limits in order to allow this component
       # to autoscale properly.
-      resources = { # TODO Maybe these resources should be different from the repo_server one.
-        requests = { for k, v in var.resources.repo_server.requests : k => v if v != null }
-        limits   = { for k, v in var.resources.repo_server.limits : k => v if v != null }
+      resources = {
+        requests = { for k, v in var.resources.helmfile_cmp.requests : k => v if v != null }
+        limits   = { for k, v in var.resources.helmfile_cmp.limits : k => v if v != null }
       }
     }
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,28 @@ variable "resources" {
       }), {})
     }), {})
 
+    kustomized_helm_cmp = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }), {})
+    }), {})
+
+    helmfile_cmp = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "100m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }), {})
+    }), {})
+
     server = optional(object({
       requests = optional(object({
         cpu    = optional(string, "50m")


### PR DESCRIPTION
## Description of the changes

This PR allows more granularity in setting the requests/limits for the `repo-server` component by allowing to set the requests/limits separately for the Config Management Plugins attached to said component.

## Breaking change

- [x] No
