### PR TITLE
feat: update prometheus rule to be more flexible

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -223,6 +223,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -232,8 +234,6 @@ The following providers are used by this module:
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -695,8 +695,8 @@ Description: Map of extra accounts that were created and their tokens.
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -223,8 +223,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -234,6 +232,8 @@ The following providers are used by this module:
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -753,7 +753,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -223,6 +223,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
@@ -232,8 +234,6 @@ The following providers are used by this module:
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -692,12 +692,12 @@ Description: Map of extra accounts that were created and their tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -753,7 +753,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -201,9 +201,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -201,9 +201,9 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_helm]] <<provider_helm,helm>> |>= 2
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -26,7 +26,7 @@ argo-cd:
             labels:
               severity: warning
             annotations:
-              summary: "{{$labels.name}} Application not synchronized"
+              summary: "{{ $labels.name }} application not synchronized"
               description: |
                 {{ "Sync status: {{ $labels.sync_status }}" }}
                 {{ "Health status: {{ $labels.health_status }}" }}

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -26,7 +26,7 @@ argo-cd:
             labels:
               severity: warning
             annotations:
-              summary: The ArgoCD application is not syncronized.
+              summary: "{{$labels.name}} Application not synchronized"
               description: |
                 {{ "Sync status: {{ $labels.sync_status }}" }}
                 {{ "Health status: {{ $labels.health_status }}" }}

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -20,15 +20,17 @@ argo-cd:
                 Argo CD has not reported any applications data for the past 15 minutes which
                 means that it must be down or not functioning properly.  This needs to be
                 resolved for this cloud to continue to maintain state.
-          - alert: ArgoAppNotSynced
-            expr: |
-              argocd_app_info{sync_status!="Synced"} == 1
-            for: 12h
+          - alert: ArgoCDSync
+            expr: label_replace(argocd_app_info{sync_status!="Synced"}, "namespace", "$1", "dest_namespace", "(.*)") > 0
+            for: 60m
             labels:
               severity: warning
             annotations:
-              summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
-              description: >
-                The application [{{`{{$labels.name}}`}} has not been synchronized for over
-                12 hours which means that the state of this cloud has drifted away from the
-                state inside Git.
+              summary: The ArgoCD application is not syncronized.
+              description: |
+                {{ "Sync status: {{ $labels.sync_status }}" }}
+                {{ "Health status: {{ $labels.health_status }}" }}
+                {{ "Namespace: {{ $labels.dest_namespace }}" }}
+                {{ "Application: {{ $labels.name }}" }}
+                {{ "Project: {{ $labels.project }}" }}
+                {{ "Repository: {{ $labels.repo }}" }}


### PR DESCRIPTION
## Description of the changes

This PR updates the Prometheus rule for monitoring Argo CD applications' sync status. The current rule checks if there is exactly one application that is out of sync. This update replaces it with a more flexible rule that triggers when there is at least one out-of-sync application, while also ensuring the presence of the namespace label for better context in alerts.

## Breaking change

- [x] No

