### PR TITLE
feat!: point the Argo CD provider to the new repository

### DIFF
--- a/bootstrap/terraform.tf
+++ b/bootstrap/terraform.tf
@@ -25,7 +25,7 @@ terraform {
       version = ">= 0.9"
     }
     argocd = {
-      source  = "oboukili/argocd"
+      source  = "argoproj-labs/argocd"
       version = ">= 6"
     }
   }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     argocd = {
-      source  = "oboukili/argocd"
-      version = ">= 5"
+      source  = "argoproj-labs/argocd"
+      version = ">= 6"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

About two months ago, the Argo CD provider we use was moved under the umbrella of `argoproj-labs`. The move is now completed and the provider will no longer be available under `oboukili/argocd` but instead `argoproj-labs/argocd` . Version 6.2.0 of the provider is available under both, but they released v7.0.0 last week to finalize the migration.

Note the following:
- the v7 does not contain any changes to the API and serves only to mark the end of the move;
- the GPG key used to sign the provider is no longer the personal one from oboukili but instead the one from the argoproj-labs;
- the migration guide is [here](https://github.com/argoproj-labs/terraform-provider-argocd?tab=readme-ov-file#migrate-provider-source-oboukili---argoproj-labs);
- the release notes are [here](https://github.com/argoproj-labs/terraform-provider-argocd/releases/tag/v7.0.0);

## Breaking change

- [x] Yes: I've marked this as a breaking change because this upgrade will require that the users **upgrade all their modules at the same time**.

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] KinD
- [x] SKS (Exoscale)
