### PR TITLE
fix(charts): add release in file name to avoid duplicates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
+Default: `"v7.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -753,7 +753,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
+|`"v7.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -79,11 +79,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_random]] <<provider_random,random>> (>= 3)
+
 - [[provider_jwt]] <<provider_jwt,jwt>> (>= 1.1)
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
-
-- [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_helm]] <<provider_helm,helm>> (>= 2)
 

--- a/charts/argocd/templates/grafana-dashboard.yaml
+++ b/charts/argocd/templates/grafana-dashboard.yaml
@@ -17,7 +17,7 @@ items:
     labels:
       grafana_dashboard: '1'
   data:
-    {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
+    {{ $.Release.Name }}-{{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argocd/templates/grafana-dashboard.yaml
+++ b/charts/argocd/templates/grafana-dashboard.yaml
@@ -1,4 +1,4 @@
-{{- if or (index .Values "argo-cd" "controller" "metrics" "serviceMonitor" "enabled") 
+{{- if or (index .Values "argo-cd" "controller" "metrics" "serviceMonitor" "enabled")
           (or (index .Values "argo-cd" "repoServer" "metrics" "serviceMonitor" "enabled")
               (index .Values "argo-cd" "server" "metrics" "serviceMonitor" "enabled")
           )


### PR DESCRIPTION
## Description of the changes

Grafana does not manage/support to have multiple dashboards with the same filename so I added the release name as a prefix to avoid duplicates with other modules.

## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [X] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)