### PR TITLE
feat!: make version working with helm v3 provider

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -229,9 +229,9 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1.6)
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
@@ -310,7 +310,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.1.0"`
+Default: `"v7.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -695,8 +695,8 @@ Description: Map of extra accounts that were created and their tokens.
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
+|[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
@@ -753,7 +753,7 @@ Description: Map of extra accounts that were created and their tokens.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.1.0"`
+|`"v7.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/bootstrap/README.adoc
+++ b/bootstrap/README.adoc
@@ -63,7 +63,7 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 6)
 
-- [[requirement_helm]] <<requirement_helm,helm>> (>= 2)
+- [[requirement_helm]] <<requirement_helm,helm>> (>= 3)
 
 - [[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> (>= 1)
 
@@ -85,7 +85,7 @@ The following providers are used by this module:
 
 - [[provider_time]] <<provider_time,time>> (>= 0.9)
 
-- [[provider_helm]] <<provider_helm,helm>> (>= 2)
+- [[provider_helm]] <<provider_helm,helm>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
 
@@ -188,7 +188,7 @@ Description: The Argo CD accounts pipeline tokens.
 |Name |Version
 |[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 1.2
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 6
-|[[requirement_helm]] <<requirement_helm,helm>> |>= 2
+|[[requirement_helm]] <<requirement_helm,helm>> |>= 3
 |[[requirement_htpasswd]] <<requirement_htpasswd,htpasswd>> |>= 1
 |[[requirement_jwt]] <<requirement_jwt,jwt>> |>= 1.1
 |[[requirement_random]] <<requirement_random,random>> |>= 3
@@ -201,10 +201,10 @@ Description: The Argo CD accounts pipeline tokens.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_jwt]] <<provider_jwt,jwt>> |>= 1.1
 |[[provider_time]] <<provider_time,time>> |>= 0.9
-|[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_helm]] <<provider_helm,helm>> |>= 2
+|[[provider_helm]] <<provider_helm,helm>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1.6
 |[[provider_null]] <<provider_null,null>> |n/a

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -5,7 +5,7 @@ output "id" {
 
 output "argocd_namespace" {
   description = "The namespace where Argo CD resides. The main use of this output is to create an implicit dependency when passing this attribute to the oboukili/argocd provider settings."
-  value       = helm_release.argocd.metadata.0.namespace
+  value       = helm_release.argocd.metadata.namespace
 }
 
 output "argocd_project_names" {

--- a/bootstrap/terraform.tf
+++ b/bootstrap/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2"
+      version = ">= 3"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## Description of the changes

Hello.

One of our customer tried to upgrade the helm provider in a root module with this submodule in dependency and had following error:
```
╷
│ Error: Invalid index
│
│   on .terraform/modules/argocd_bootstrap_dev/bootstrap/outputs.tf line 8, in output "argocd_namespace":
│    8:   value       = helm_release.argocd.metadata.0.namespace
│     ├────────────────
│     │ helm_release.argocd.metadata is object with 10 attributes
│
│ The given key does not identify an element in this collection value. An object only supports looking up attributes by name, not by numeric index.
```

So here is a new version that works with the helm provider v3.


## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [X] Yes (in the module itself): See the migration [guide](https://github.com/hashicorp/terraform-provider-helm/blob/main/docs/guides/v3-upgrade-guide.md)

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [X] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)